### PR TITLE
Fixes date calculations

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,8 +1,8 @@
 //set values according to the URL parameters if it exists, using defaults if they don't
-var pageUrl = new URLSearchParams(location.search);
-var daysPerYear = pageUrl.get("daysperyear") ? pageUrl.get("daysperyear")/1 : 14;
-var lastDateChange = pageUrl.get("lastdatechange") ? pageUrl.get("lastdatechange")/1 : 1533081600000; //JS time adds three zeroes to UNIX time
-var lastDateEpoch = pageUrl.get("lastdateepoch") ? pageUrl.get("lastdateepoch")/1 : 1104537600000;
+const pageUrl = new URLSearchParams(location.search);
+let daysPerYear = pageUrl.get("daysperyear") ? pageUrl.get("daysperyear")/1 : 14;
+let lastDateChange = pageUrl.get("lastdatechange") ? pageUrl.get("lastdatechange")/1 : 1533081600000; //JS time adds three zeroes to UNIX time
+let lastDateEpoch = pageUrl.get("lastdateepoch") ? pageUrl.get("lastdateepoch")/1 : 1104537600000;
 
 //change the HTML elements to reflect the values
 document.getElementById("daysPerYear").value = daysPerYear;
@@ -16,35 +16,49 @@ function setSettings(){
 }
 
 function exportSettings(){
-    var paramString = "?";
-    paramString += "daysperyear=" + daysPerYear;
-    paramString += "&lastdatechange=" + lastDateChange;
-    paramString += "&lastdateepoch=" + lastDateEpoch;
-    window.prompt("Copy the following link:", [location.protocol, "//", location.host, location.pathname].join('') + paramString);
+    const parameters = 
+        `?daysperYear=${daysPerYear}&lastdatechange=${lastDateChange}&lastdateepoch=${lastDateEpoch}`;
+    const link = `${location.protocol}//${location.host}${location.pathname}`;
+    window.prompt("Copy the following link:", link+parameters);
 }
 
-function getTimeOf(irlDate){
-    return new Date(Math.floor((365/daysPerYear)*((irlDate)-lastDateChange)+lastDateEpoch));
+function getTimeOf(irlDate) {
+    const day = 86400000; //The length of the day
+
+    const timeDifference = irlDate-lastDateChange;
+    
+    const years = timeDifference/(day*daysPerYear);
+    const yearCount = Math.floor(years);
+
+    const lastDate = new Date(lastDateEpoch);
+
+    const earlyDate = lastDate.setFullYear(lastDate.getFullYear() + yearCount);
+    const latestDate = lastDate.setFullYear(lastDate.getFullYear() + 1);
+    const yearLength = latestDate - earlyDate;
+
+    const rest = (years - yearCount)*yearLength; //Portion of the year
+
+    return new Date(earlyDate + rest);
 }
 
 function setTime(){
-    var display = document.getElementById("timeDisplay");
-    var rpJSTime = getTimeOf(Date.now());
+    const display = document.getElementById("timeDisplay");
+    const rpJSTime = getTimeOf(Date.now());
     display.innerHTML = "The RP date and time is<br>" + rpJSTime.toGMTString();
 }
 
 function getSingleRPTime(){
-    var singleDisplay = document.getElementById("singleRPTimeDisplay");
-    var singleIRLTime = document.getElementById("singleTime").value.split(":");
+    const singleDisplay = document.getElementById("singleRPTimeDisplay");
+    let singleIRLTime = document.getElementById("singleTime").value.split(":");
     singleIRLTime = parseInt(singleIRLTime[0]*60) + parseInt(singleIRLTime[1]); //get selected IRL time in minutes
     singleIRLTime *= 60000; //make it milliseconds
-    var singleIRLOffset = document.getElementById("singleOffset").value; //get selected IRL timezone in hours
+    let singleIRLOffset = document.getElementById("singleOffset").value; //get selected IRL timezone in hours
     singleIRLOffset *= 3600000; //make it milliseconds
     singleIRLTime -= singleIRLOffset; //subtract the offset from the time to make it UTC
 
-    var singleIRLDate = document.getElementById("singleDate").value; //get the value of the date picker
+    let singleIRLDate = document.getElementById("singleDate").value; //get the value of the date picker
     singleIRLDate = new Date(singleIRLDate)/1; //turn it into js time (milliseconds)
-    var dateTime = new Date(singleIRLDate + singleIRLTime)/1;
+    const dateTime = new Date(singleIRLDate + singleIRLTime)/1;
 
     singleDisplay.innerHTML = getTimeOf(dateTime).toGMTString();
 }


### PR DESCRIPTION
The previous version of `getTimeOf` assumed that every year is 365 days long, which leads to years becoming longer than whatever is set in `daysPerYear` whenever a leap year occurs.