### PR TITLE
Correct mistake in URL construction

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 //set values according to the URL parameters if it exists, using defaults if they don't
 const pageUrl = new URLSearchParams(location.search);
 let daysPerYear = pageUrl.get("daysperyear") ? pageUrl.get("daysperyear")/1 : 14;
+daysPerYear = pageUrl.get("daysperYear") ? pageUrl.get("daysperYear")/1 : daysPerYear; //To cover the mistake
 let lastDateChange = pageUrl.get("lastdatechange") ? pageUrl.get("lastdatechange")/1 : 1533081600000; //JS time adds three zeroes to UNIX time
 let lastDateEpoch = pageUrl.get("lastdateepoch") ? pageUrl.get("lastdateepoch")/1 : 1104537600000;
 let fixedYears = pageUrl.get("fixedyears") ? pageUrl.get("fixedyears") === "true" : false;
@@ -12,7 +13,7 @@ document.getElementById("lastDateEpoch").value = new Date(lastDateEpoch).toISOSt
 document.getElementById("fixedYears").checked = fixedYears;
 
 function getSettingsUrl() {
-    const parameters = `?daysperYear=${daysPerYear}&lastdatechange=${lastDateChange}&lastdateepoch=${lastDateEpoch}&fixedyears=${fixedYears}`;
+    const parameters = `?daysperyear=${daysPerYear}&lastdatechange=${lastDateChange}&lastdateepoch=${lastDateEpoch}&fixedyears=${fixedYears}`;
     const link = `${location.protocol}//${location.host}${location.pathname}`;
     return link + parameters;
 }
@@ -22,9 +23,6 @@ function setSettings() {
     lastDateChange = new Date(document.getElementById("lastDateChange").value)/1; //the /1 turns it into a number
     lastDateEpoch = new Date(document.getElementById("lastDateEpoch").value)/1;
     fixedYears = document.getElementById("fixedYears").checked;
-    const parameters = 
-    `?daysperYear=${daysPerYear}&lastdatechange=${lastDateChange}&lastdateepoch=${lastDateEpoch}&fixedyears=${fixedYears}`;
-    const link = `${location.protocol}//${location.host}${location.pathname}`;
     window.history.replaceState(null, "", getSettingsUrl());
 }
 


### PR DESCRIPTION
In very short, due to a `daysperyear` being spelled as `daysperYear` the website incorrectly read the time for new calculations